### PR TITLE
Add a template containing new values for initial timeouts

### DIFF
--- a/overrides/timeouts.yaml
+++ b/overrides/timeouts.yaml
@@ -1,0 +1,4 @@
+liveness:
+  initialDelaySeconds: 100
+readiness:
+  initialDelaySeconds: 100


### PR DESCRIPTION
to account for our poor old cluster slowness